### PR TITLE
Fix config reference for email service

### DIFF
--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -1,6 +1,9 @@
 const nodemailer = require('nodemailer');
 const templates = require('./emailTemplates');
-const config = require('../config');
+// Load application configuration (env vars, client URL, email settings, etc.)
+// Explicitly require the config directory's index.js to avoid accidentally
+// importing the scraping config located at server/config.js.
+const config = require('../config/index');
 
 class EmailService {
   constructor() {

--- a/server/services/emailTemplates.js
+++ b/server/services/emailTemplates.js
@@ -1,4 +1,7 @@
-const config = require('../config');
+// Load environment and application configuration values.
+// Using the explicit path prevents Node from resolving to server/config.js,
+// which doesn't contain the settings required for email templates.
+const config = require('../config/index');
 
 const baseTemplate = (content) => `
 <!DOCTYPE html>

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,5 +1,7 @@
 const winston = require('winston');
-const config = require('../config');
+// Pull in the main application configuration rather than the scraping
+// configuration file located at server/config.js.
+const config = require('../config/index');
 const path = require('path');
 
 // Create logs directory if it doesn't exist


### PR DESCRIPTION
## Summary
- point email service and utilities to config/index.js to load env-based settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b37f5770832ca08cf2138f27ecff