### PR TITLE
Fix search clearing on category click

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -214,12 +214,16 @@ function AppContent() {
   }, []);
 
   const handleCategoryClick = useCallback((category: string) => {
+    setSearchQuery('');
+    setSearchResults([]);
     setSelectedCategory(prevCategory => prevCategory === category ? null : category);
     setSelectedSubcategory(null);
   }, []);
 
   const handleSubcategoryClick = useCallback((subcategory: string) => {
-    setSelectedSubcategory(prevSubcategory => 
+    setSearchQuery('');
+    setSearchResults([]);
+    setSelectedSubcategory(prevSubcategory =>
       prevSubcategory === subcategory ? null : subcategory
     );
   }, []);


### PR DESCRIPTION
## Summary
- clear search when choosing a category or subcategory so navigation resets

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bab34d7c832caf94232330754b01