### PR TITLE
Fix search ignoring category selection

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -176,10 +176,13 @@ function AppContent() {
     if (!baseDeals) return [];
     let filtered = [...baseDeals];
 
-    if (selectedCategory) {
-      filtered = filtered.filter(deal => deal.category === selectedCategory);
-      if (selectedSubcategory) {
-        filtered = filtered.filter(deal => deal.subcategory === selectedSubcategory);
+    // When searching, ignore previously selected category filters
+    if (!searchQuery) {
+      if (selectedCategory) {
+        filtered = filtered.filter(deal => deal.category === selectedCategory);
+        if (selectedSubcategory) {
+          filtered = filtered.filter(deal => deal.subcategory === selectedSubcategory);
+        }
       }
     }
 
@@ -248,7 +251,14 @@ function AppContent() {
               placeholder="Search for the best deals..."
               className="search-input"
               value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
+              onChange={(event) => {
+                const value = event.target.value;
+                setSearchQuery(value);
+                if (value) {
+                  setSelectedCategory(null);
+                  setSelectedSubcategory(null);
+                }
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- ignore category filters when searching for deals
- reset category selections when typing in the search bar

## Testing
- `npm test --silent` in `server`
- `CI=true npm test --silent -- --passWithNoTests` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6841bc427168832cbb9cf70b6e4c44c5