### PR TITLE
Improve back button style on auth pages

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -12,6 +12,7 @@ import {
   Alert,
   Checkbox,
   FormControlLabel,
+  alpha,
 } from '@mui/material';
 import {
   Visibility,
@@ -189,7 +190,14 @@ const LoginPage: React.FC<LoginPageProps> = ({ setIsAuthenticated, setUser }) =>
       >
         <IconButton
           onClick={() => navigate('/')}
-          sx={{ alignSelf: 'flex-start', mb: 2 }}
+          sx={{
+            alignSelf: 'flex-start',
+            mb: 2,
+            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
+            '&:hover': {
+              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.2),
+            },
+          }}
         >
           <ArrowBackIcon />
         </IconButton>

--- a/client/src/pages/SignupPage.tsx
+++ b/client/src/pages/SignupPage.tsx
@@ -11,6 +11,7 @@ import {
   CircularProgress,
   Alert,
   Stack,
+  alpha,
 } from '@mui/material';
 import {
   Visibility,
@@ -154,14 +155,14 @@ const SignupPage: React.FC<SignupPageProps> = ({ setIsAuthenticated, setUser }) 
           pb: 8, // Add padding at bottom
         }}
       >
-        <IconButton 
-          onClick={() => navigate('/')} 
-          sx={{ 
-            alignSelf: 'flex-start', 
+        <IconButton
+          onClick={() => navigate('/')}
+          sx={{
+            alignSelf: 'flex-start',
             mb: 2,
-            bgcolor: (theme) => theme.palette.grey[100],
+            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
             '&:hover': {
-              bgcolor: (theme) => theme.palette.grey[200],
+              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.2),
             },
           }}
         >


### PR DESCRIPTION
## Summary
- style login page back button to match deal alerts page
- style sign-up page back button similarly

## Testing
- `npm install`
- `npm test --silent --yes` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6841be646954832cb298947d9de2b8e9