### PR TITLE
Fix login page navigation

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -292,14 +292,14 @@ const LoginPage: React.FC<LoginPageProps> = ({ setIsAuthenticated, setUser }) =>
             {loading ? <CircularProgress size={24} /> : 'Log In'}
           </Button>
 
-          <Box sx={{ textAlign: 'center' }}>
-            <Link href="#" variant="body2" onClick={() => navigate('/signup')} sx={{ mb: 2, display: 'block' }}>
-              Don't have an account? Sign up
-            </Link>
-            <Link href="#" variant="body2" onClick={() => navigate('/forgot-password')}>
-              Forgot password?
-            </Link>
-          </Box>
+        </Box>
+        <Box sx={{ textAlign: 'center' }}>
+          <Link href="#" variant="body2" onClick={() => navigate('/signup')} sx={{ mb: 2, display: 'block' }}>
+            Don't have an account? Sign up
+          </Link>
+          <Link href="#" variant="body2" onClick={() => navigate('/forgot-password')}>
+            Forgot password?
+          </Link>
         </Box>
       </Box>
     </Container>


### PR DESCRIPTION
## Summary
- fix the position of navigation links on the login page so clicking them doesn't trigger form validation

## Testing
- `npm test --prefix client --silent -- --watchAll=false` *(fails: react-scripts not found)*
