### PR TITLE
Fix login link validation

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -296,6 +296,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ setIsAuthenticated, setUser }) =>
         <Box sx={{ textAlign: 'center' }}>
           <Link
             component="button"
+            type="button"
             variant="body2"
             onClick={() => navigate('/signup')}
             sx={{ mb: 2, display: 'block' }}
@@ -304,6 +305,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ setIsAuthenticated, setUser }) =>
           </Link>
           <Link
             component="button"
+            type="button"
             variant="body2"
             onClick={() => navigate('/forgot-password')}
           >


### PR DESCRIPTION
## Summary
- prevent login form validation when clicking `Sign up` or `Forgot password` links

## Testing
- `npm test --silent --progress=false`